### PR TITLE
feat: add environment configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+NODE_ENV=development
+PORT=4000
+
+SLACK_APP_TOKEN=xapp-your-app-token
+SLACK_BOT_TOKEN=xoxb-your-bot-token
+SLACK_SIGNING_SECRET=your-signing-secret
+
+NEXT_PUBLIC_API_BASE=http://localhost:4000

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.env
+dist

--- a/apps/api/src/config/config.module.ts
+++ b/apps/api/src/config/config.module.ts
@@ -1,0 +1,7 @@
+import { ConfigModule } from '@nestjs/config';
+import { envValidationSchema } from './env.validation';
+
+export const AppConfigModule = ConfigModule.forRoot({
+  isGlobal: true,
+  validationSchema: envValidationSchema,
+});

--- a/apps/api/src/config/env.validation.ts
+++ b/apps/api/src/config/env.validation.ts
@@ -1,0 +1,10 @@
+import * as Joi from 'joi';
+
+export const envValidationSchema = Joi.object({
+  NODE_ENV: Joi.string().valid('development', 'production', 'test').default('development'),
+  PORT: Joi.number().default(4000),
+  SLACK_APP_TOKEN: Joi.string().required(),
+  SLACK_BOT_TOKEN: Joi.string().required(),
+  SLACK_SIGNING_SECRET: Joi.string().optional(),
+  NEXT_PUBLIC_API_BASE: Joi.string().uri().required(),
+});

--- a/apps/web/src/config.ts
+++ b/apps/web/src/config.ts
@@ -1,0 +1,1 @@
+export const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:4000';


### PR DESCRIPTION
## Summary
- add `.env.example` with Slack tokens and API base
- validate backend environment variables with Joi in a global `ConfigModule`
- expose `NEXT_PUBLIC_API_BASE` to the web app

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c57fec64832fac874c6246c17f01